### PR TITLE
Feat/extract userid from decoded token

### DIFF
--- a/backend/internal/handler/distributor_handler.go
+++ b/backend/internal/handler/distributor_handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/deveasyclick/tilvio/internal/service"
+	"github.com/deveasyclick/tilvio/pkg/context"
 )
 
 type DistributorHandler interface {
@@ -17,10 +18,10 @@ type distributorHandler struct {
 }
 
 func (h *distributorHandler) GetAuthenticated(w http.ResponseWriter, r *http.Request) {
-	distributorClerkId := r.Context().Value("userClerkId").(string)
-	distributor, err := h.service.GetDistributorByClerkID(distributorClerkId, "Workspace")
+	distributorId := context.GetActiveUserID(r.Context())
+	distributor, err := h.service.GetDistributorByID(distributorId, []string{"Workspace"})
 	if err != nil {
-		slog.Error("failed to get distributor", "error", err, "clerkId", distributorClerkId)
+		slog.Error("failed to get distributor", "error", err, "user Id", distributorId)
 		http.Error(w, "failed to get distributor, try again later", http.StatusInternalServerError)
 		return
 	}

--- a/backend/internal/handler/workspace_handler.go
+++ b/backend/internal/handler/workspace_handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/deveasyclick/tilvio/internal/models"
 	"github.com/deveasyclick/tilvio/internal/service"
+	"github.com/deveasyclick/tilvio/pkg/context"
 	"github.com/deveasyclick/tilvio/pkg/types"
 	"github.com/deveasyclick/tilvio/pkg/validator"
 	"github.com/go-chi/chi"
@@ -52,8 +53,8 @@ func (h *workspaceHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Country:          req.Country,
 	}
 
-	distributorClerkId := r.Context().Value("userClerkId").(string)
-	if err := h.service.Create(&workspace, distributorClerkId); err != nil {
+	distributorID := context.GetActiveUserID(r.Context())
+	if err := h.service.Create(&workspace, distributorID); err != nil {
 		slog.Error("failed to create workspace", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -6,13 +6,21 @@ import (
 
 	"github.com/clerk/clerk-sdk-go/v2"
 	clerkHttp "github.com/clerk/clerk-sdk-go/v2/http"
+	"github.com/deveasyclick/tilvio/pkg/types"
 )
 
-type CustomSessionClaims struct {
-	UserID *string `json:"userId"`
+func customClaimsConstructor(ctx context.Context) any {
+	return &types.CustomSessionClaims{}
+}
+
+func WithCustomClaimsConstructor(params *clerkHttp.AuthorizationParams) error {
+	params.VerifyParams.CustomClaimsConstructor = customClaimsConstructor
+	return nil
 }
 
 func AuthRequiredMiddleware(opts ...clerkHttp.AuthorizationOption) func(http.Handler) http.Handler {
+	// Extract custom claims from the request
+	opts = append(opts, WithCustomClaimsConstructor)
 	return func(next http.Handler) http.Handler {
 		return clerkHttp.WithHeaderAuthorization(opts...)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			claims, ok := clerk.SessionClaimsFromContext(r.Context())
@@ -22,8 +30,8 @@ func AuthRequiredMiddleware(opts ...clerkHttp.AuthorizationOption) func(http.Han
 				w.Write([]byte(`{"message": "unauthorized"}`))
 				return
 			}
-			// TODO: This should be a user ID, not a Clerk ID but we need to figure out how to get the user ID from Clerk
-			ctx := context.WithValue(r.Context(), "userClerkId", claims.Subject)
+			customClaims := claims.Custom.(*types.CustomSessionClaims)
+			ctx := context.WithValue(r.Context(), types.ActiveSessionUserId, *customClaims.UserId)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		}))
 	}

--- a/backend/internal/service/distributor_service.go
+++ b/backend/internal/service/distributor_service.go
@@ -19,10 +19,10 @@ const (
 
 type DistributorService interface {
 	Create(distributor *models.Distributor) error
-	UpdateDistributor(ID uint, distributor *models.Distributor) error
+	UpdateDistributor(ID string, distributor *models.Distributor) error
 	DeleteDistributor(id string) error
 	GetDistributorByEmail(email string) (*models.Distributor, error)
-	GetDistributorByClerkID(clerkID string, preloads ...string) (*models.Distributor, error)
+	GetDistributorByID(ID string, preloads []string) (*models.Distributor, error)
 }
 
 type distributorService struct {
@@ -31,7 +31,7 @@ type distributorService struct {
 
 func (s *distributorService) Create(distributor *models.Distributor) error {
 	// Check if distributor already exists
-	existing, err := s.repo.FindByEmail(distributor.Email)
+	existing, err := s.repo.FindOneWithFields(map[string]any{"email": distributor.Email}, []string{"id"}, nil)
 	if err == nil && existing != nil {
 		return errors.New(errDistributorExists)
 	}
@@ -44,7 +44,7 @@ func (s *distributorService) Create(distributor *models.Distributor) error {
 	return nil
 }
 
-func (s *distributorService) UpdateDistributor(ID uint, distributor *models.Distributor) error {
+func (s *distributorService) UpdateDistributor(ID string, distributor *models.Distributor) error {
 	err := s.repo.Update(ID, distributor)
 	if err != nil {
 		return fmt.Errorf(errFormat, errUpdateDistributor, err)
@@ -55,7 +55,7 @@ func (s *distributorService) UpdateDistributor(ID uint, distributor *models.Dist
 
 func (s *distributorService) DeleteDistributor(id string) error {
 	// Check if distributor exists
-	existing, err := s.repo.FindByID(id)
+	existing, err := s.repo.FindOneWithFields(map[string]any{"id": id}, []string{"id"}, nil)
 	if err != nil || existing == nil {
 		return errors.New(errDistributorNotFound)
 	}
@@ -64,7 +64,7 @@ func (s *distributorService) DeleteDistributor(id string) error {
 }
 
 func (s *distributorService) GetDistributorByEmail(email string) (*models.Distributor, error) {
-	distributor, err := s.repo.FindByEmail(email)
+	distributor, err := s.repo.FindOneWithFields(map[string]any{"email": email}, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf(errFormat, errFindDistributor, err)
 	}
@@ -72,8 +72,8 @@ func (s *distributorService) GetDistributorByEmail(email string) (*models.Distri
 	return distributor, nil
 }
 
-func (s *distributorService) GetDistributorByClerkID(clerkID string, preloads ...string) (*models.Distributor, error) {
-	distributor, err := s.repo.FindByClerkID(clerkID, preloads...)
+func (s *distributorService) GetDistributorByID(ID string, preloads []string) (*models.Distributor, error) {
+	distributor, err := s.repo.FindOneWithFields(map[string]any{"id": ID}, nil, preloads)
 	if err != nil {
 		return nil, fmt.Errorf(errFormat, errFindDistributor, err)
 	}

--- a/backend/internal/service/workspace_service.go
+++ b/backend/internal/service/workspace_service.go
@@ -17,7 +17,7 @@ const (
 )
 
 type WorkspaceService interface {
-	Create(workspace *models.Workspace, distributorClerkID string) error
+	Create(workspace *models.Workspace, distributorID string) error
 	Update(workspace *models.Workspace) error
 	Delete(ID uint) error
 	GetWorkspace(ID uint) (*models.Workspace, error)
@@ -28,18 +28,13 @@ type workspaceService struct {
 	distributorService DistributorService
 }
 
-func (s *workspaceService) Create(workspace *models.Workspace, distributorClerkID string) error {
-	distributor, err := s.distributorService.GetDistributorByClerkID(distributorClerkID)
-	if err != nil {
-		return fmt.Errorf("error finding distributor by clerkID: %w", err)
-	}
-
-	if err = s.repo.Create(workspace); err != nil {
+func (s *workspaceService) Create(workspace *models.Workspace, distributorID string) error {
+	if err := s.repo.Create(workspace); err != nil {
 		return fmt.Errorf("error creating workspace: %w", err)
 	}
 
 	workspaceID := workspace.ID
-	err = s.distributorService.UpdateDistributor(distributor.ID, &models.Distributor{WorkspaceID: &workspaceID})
+	err := s.distributorService.UpdateDistributor(distributorID, &models.Distributor{WorkspaceID: &workspaceID})
 	if err != nil {
 		return fmt.Errorf("error attaching workspace to distributor: %w", err)
 	}

--- a/backend/pkg/context/webhook.go
+++ b/backend/pkg/context/webhook.go
@@ -23,3 +23,7 @@ func GetWebhookEvent(ctx context.Context) *types.WebhookEvent {
 	event, _ := ctx.Value(webhookEventKey).(*types.WebhookEvent)
 	return event
 }
+
+func GetActiveUserID(ctx context.Context) string {
+	return ctx.Value(types.ActiveSessionUserId).(string)
+}

--- a/backend/pkg/types/session_claims.go
+++ b/backend/pkg/types/session_claims.go
@@ -1,0 +1,9 @@
+package types
+
+type CustomSessionClaims struct {
+	UserId *string `json:"user_id"`
+}
+
+const (
+	ActiveSessionUserId = "session_user_id"
+)


### PR DESCRIPTION
- Extract custom field `user_id` from JWT token (Slack external ID) for consistent user identification
The `user_id` field is extracted from the decoded JWT token. This value corresponds to the Slack external ID 
and is used to identify active users in our database. Centralizing this extraction allows us to access the user ID consistently throughout the application.

- Improve distributor repository and service to:
    - Take ID as string instead of uint
    - Use new method `findOneWithField`  that allow fields selections and model preloads

- Update distributor and workspace handlers to use `user_id` from context instead of `clerkUserId`

- Improve workspace creation method to not find distributor before creating the workspace, and just use the user_id from context