### PR TITLE
Improve logic for retrieving authenticated user data from request

### DIFF
--- a/backend/internal/handler/distributor_handler.go
+++ b/backend/internal/handler/distributor_handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/deveasyclick/tilvio/internal/service"
 	"github.com/deveasyclick/tilvio/pkg/context"
+	"github.com/deveasyclick/tilvio/pkg/types/error_messages"
 )
 
 type DistributorHandler interface {
@@ -18,17 +19,17 @@ type distributorHandler struct {
 }
 
 func (h *distributorHandler) GetAuthenticated(w http.ResponseWriter, r *http.Request) {
-	distributorId := context.GetActiveUserID(r.Context())
-	distributor, err := h.service.GetDistributorByID(distributorId, []string{"Workspace"})
+	user := context.GetAuthenticatedUser(r.Context())
+	distributor, err := h.service.GetDistributorByID(user.ID, []string{"Workspace"})
 	if err != nil {
-		slog.Error("failed to get distributor", "error", err, "user Id", distributorId)
-		http.Error(w, "failed to get distributor, try again later", http.StatusInternalServerError)
+		slog.Error(error_messages.ErrFindDistributor, "error", err, "user Id", user.ID)
+		http.Error(w, error_messages.ErrFindDistributor, http.StatusInternalServerError)
 		return
 	}
 
 	if err := json.NewEncoder(w).Encode(distributor); err != nil {
-		slog.Error("Failed to encode response", "error", err)
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		slog.Error(error_messages.ErrEncodeResponseFailed, "error", err)
+		http.Error(w, error_messages.ErrEncodeResponseFailed, http.StatusInternalServerError)
 	}
 }
 

--- a/backend/internal/handler/workspace_handler.go
+++ b/backend/internal/handler/workspace_handler.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/deveasyclick/tilvio/internal/models"
 	"github.com/deveasyclick/tilvio/internal/service"
+	"github.com/deveasyclick/tilvio/internal/usecases"
 	"github.com/deveasyclick/tilvio/pkg/context"
 	"github.com/deveasyclick/tilvio/pkg/types"
+	"github.com/deveasyclick/tilvio/pkg/types/error_messages"
 	"github.com/deveasyclick/tilvio/pkg/validator"
 	"github.com/go-chi/chi"
 )
@@ -28,7 +30,8 @@ type WorkspaceHandler interface {
 }
 
 type workspaceHandler struct {
-	service service.WorkspaceService
+	service           service.WorkspaceService
+	createWorkspaceUC usecases.CreateWorkspaceUseCase
 }
 
 func (h *workspaceHandler) Create(w http.ResponseWriter, r *http.Request) {
@@ -53,17 +56,22 @@ func (h *workspaceHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Country:          req.Country,
 	}
 
-	distributorID := context.GetActiveUserID(r.Context())
-	if err := h.service.Create(&workspace, distributorID); err != nil {
-		slog.Error("failed to create workspace", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	authenticatedUser := context.GetAuthenticatedUser(r.Context())
+	err := h.createWorkspaceUC.Execute(usecases.CreateWorkspaceInput{
+		Workspace:     workspace,
+		DistributorID: authenticatedUser.ID,
+		ClerkUserID:   authenticatedUser.ClerkID,
+	})
+
+	if err != nil {
+		slog.Error(error_messages.ErrCreateWorkspace, "error", err)
+		http.Error(w, error_messages.ErrCreateWorkspace, http.StatusInternalServerError)
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
 	if err := json.NewEncoder(w).Encode(workspace); err != nil {
-		slog.Error("Failed to encode response", "error", err)
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		slog.Error(errEncodeResponse, "error", err)
+		http.Error(w, errEncodeResponse, http.StatusInternalServerError)
 	}
 }
 
@@ -163,9 +171,12 @@ func (h *workspaceHandler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	json.NewEncoder(w).Encode(workspace)
+	if err := json.NewEncoder(w).Encode(workspace); err != nil {
+		slog.Error(error_messages.ErrEncodeResponseFailed, "error", err)
+		http.Error(w, error_messages.ErrEncodeResponseFailed, http.StatusInternalServerError)
+	}
 }
 
-func NewWorkspaceHandler(service service.WorkspaceService) WorkspaceHandler {
-	return &workspaceHandler{service: service}
+func NewWorkspaceHandler(service service.WorkspaceService, createWorkspaceUC usecases.CreateWorkspaceUseCase) WorkspaceHandler {
+	return &workspaceHandler{service: service, createWorkspaceUC: createWorkspaceUC}
 }

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -24,15 +24,13 @@ func AuthRequiredMiddleware(opts ...clerkHttp.AuthorizationOption) func(http.Han
 	return func(next http.Handler) http.Handler {
 		return clerkHttp.WithHeaderAuthorization(opts...)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			claims, ok := clerk.SessionClaimsFromContext(r.Context())
-
 			if !ok || claims == nil {
 				w.WriteHeader(http.StatusUnauthorized)
 				w.Write([]byte(`{"message": "unauthorized"}`))
 				return
 			}
-			customClaims := claims.Custom.(*types.CustomSessionClaims)
-			ctx := context.WithValue(r.Context(), types.ActiveSessionUserId, *customClaims.UserId)
-			next.ServeHTTP(w, r.WithContext(ctx))
+
+			next.ServeHTTP(w, r)
 		}))
 	}
 }

--- a/backend/internal/routes/webhook_routes.go
+++ b/backend/internal/routes/webhook_routes.go
@@ -11,7 +11,9 @@ import (
 
 func registerWebhookRoutes(r chi.Router, db *gorm.DB) {
 	distributorRepo := repository.NewDistributorRepository(db)
-	webhookSvc := service.NewWebhookService(service.NewDistributorService(distributorRepo))
+	distributorSvc := service.NewDistributorService(distributorRepo)
+	clerkSvc := service.NewClerkService()
+	webhookSvc := service.NewWebhookService(distributorSvc, clerkSvc)
 	webhookHandler := handler.NewWebhookHandler(webhookSvc)
 
 	// Public routes (no auth required, but webhook signature is verified)

--- a/backend/internal/routes/workspace_routes.go
+++ b/backend/internal/routes/workspace_routes.go
@@ -4,6 +4,7 @@ import (
 	"github.com/deveasyclick/tilvio/internal/handler"
 	"github.com/deveasyclick/tilvio/internal/repository"
 	"github.com/deveasyclick/tilvio/internal/service"
+	"github.com/deveasyclick/tilvio/internal/usecases"
 	"github.com/go-chi/chi"
 	"gorm.io/gorm"
 )
@@ -13,7 +14,9 @@ func registerWorkspaceRoutes(router chi.Router, db *gorm.DB) {
 	distributorService := service.NewDistributorService(distributorRepo)
 	workspaceRepo := repository.NewWorkspaceRepository(db)
 	workspaceSvc := service.NewWorkspaceService(workspaceRepo, distributorService)
-	workspaceHandler := handler.NewWorkspaceHandler(workspaceSvc)
+	clerkSvc := service.NewClerkService()
+	createWorkspaceUC := usecases.NewCreateWorkspaceUseCase(workspaceSvc, distributorService, clerkSvc)
+	workspaceHandler := handler.NewWorkspaceHandler(workspaceSvc, createWorkspaceUC)
 
 	// All workspace routes require authentication
 	router.Route("/workspaces", func(r chi.Router) {

--- a/backend/internal/service/clerk_service.go
+++ b/backend/internal/service/clerk_service.go
@@ -1,0 +1,36 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/clerk/clerk-sdk-go/v2/user"
+)
+
+type ClerkService interface {
+	SetWorkspace(clerkUserID string, workspaceID string) error
+	SetExternalID(userClerkID string, externalID string) error
+}
+
+type clerkService struct {
+}
+
+func (s *clerkService) SetWorkspace(userClerkID string, workspaceID string) error {
+	dataBytes, _ := json.Marshal(map[string]string{
+		"workspace_id": workspaceID,
+	})
+	raw := json.RawMessage(dataBytes)
+	_, err := user.Update(context.Background(), userClerkID, &user.UpdateParams{PublicMetadata: &raw})
+
+	return err
+}
+
+func (s *clerkService) SetExternalID(userClerkID string, externalID string) error {
+	_, err := user.Update(context.Background(), userClerkID, &user.UpdateParams{ExternalID: &externalID})
+
+	return err
+}
+
+func NewClerkService() ClerkService {
+	return &clerkService{}
+}

--- a/backend/internal/service/distributor_service.go
+++ b/backend/internal/service/distributor_service.go
@@ -23,6 +23,7 @@ type DistributorService interface {
 	DeleteDistributor(id string) error
 	GetDistributorByEmail(email string) (*models.Distributor, error)
 	GetDistributorByID(ID string, preloads []string) (*models.Distributor, error)
+	AssignWorkspace(distributorID string, workspaceID uint) error
 }
 
 type distributorService struct {
@@ -79,6 +80,16 @@ func (s *distributorService) GetDistributorByID(ID string, preloads []string) (*
 	}
 
 	return distributor, nil
+}
+
+func (s *distributorService) AssignWorkspace(distributorID string, workspaceID uint) error {
+	// Associate the workspace with the distributor
+	err := s.repo.Update(distributorID, &models.Distributor{WorkspaceID: &workspaceID})
+	if err != nil {
+		return fmt.Errorf("error attaching workspace to distributor: %w", err)
+	}
+
+	return nil
 }
 
 func NewDistributorService(repo repository.DistributorRepository) DistributorService {

--- a/backend/internal/service/workspace_service.go
+++ b/backend/internal/service/workspace_service.go
@@ -33,12 +33,6 @@ func (s *workspaceService) Create(workspace *models.Workspace, distributorID str
 		return fmt.Errorf("error creating workspace: %w", err)
 	}
 
-	workspaceID := workspace.ID
-	err := s.distributorService.UpdateDistributor(distributorID, &models.Distributor{WorkspaceID: &workspaceID})
-	if err != nil {
-		return fmt.Errorf("error attaching workspace to distributor: %w", err)
-	}
-
 	return nil
 }
 
@@ -69,5 +63,5 @@ func (s *workspaceService) GetWorkspace(ID uint) (*models.Workspace, error) {
 }
 
 func NewWorkspaceService(repo repository.WorkspaceRepository, distributorService DistributorService) WorkspaceService {
-	return &workspaceService{repo: repo, distributorService: distributorService}
+	return &workspaceService{repo: repo}
 }

--- a/backend/internal/usecases/create_workspace.go
+++ b/backend/internal/usecases/create_workspace.go
@@ -1,0 +1,53 @@
+package usecases
+
+import (
+	"fmt"
+
+	"github.com/deveasyclick/tilvio/internal/models"
+	"github.com/deveasyclick/tilvio/internal/service"
+)
+
+type CreateWorkspaceInput struct {
+	Workspace     models.Workspace
+	DistributorID string
+	ClerkUserID   string
+}
+
+type CreateWorkspaceUseCase interface {
+	Execute(input CreateWorkspaceInput) error
+}
+
+type createWorkspaceUseCase struct {
+	workspaceService   service.WorkspaceService
+	distributorService service.DistributorService
+	clerkUserService   service.ClerkService
+}
+
+func (uc *createWorkspaceUseCase) Execute(input CreateWorkspaceInput) error {
+	err := uc.workspaceService.Create(&input.Workspace, input.ClerkUserID)
+	if err != nil {
+		return err
+	}
+
+	if err := uc.distributorService.AssignWorkspace(input.DistributorID, input.Workspace.ID); err != nil {
+		return err
+	}
+
+	if err := uc.clerkUserService.SetWorkspace(input.ClerkUserID, fmt.Sprintf("%d", input.Workspace.ID)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func NewCreateWorkspaceUseCase(
+	ws service.WorkspaceService,
+	ds service.DistributorService,
+	cs service.ClerkService,
+) CreateWorkspaceUseCase {
+	return &createWorkspaceUseCase{
+		workspaceService:   ws,
+		distributorService: ds,
+		clerkUserService:   cs,
+	}
+}

--- a/backend/pkg/context/auth.go
+++ b/backend/pkg/context/auth.go
@@ -1,0 +1,25 @@
+package context
+
+import (
+	"context"
+
+	"github.com/clerk/clerk-sdk-go/v2"
+	"github.com/deveasyclick/tilvio/pkg/types"
+)
+
+type AuthenticatedUser struct {
+	ID          string
+	ClerkID     string
+	WorkspaceID string
+}
+
+func GetAuthenticatedUser(ctx context.Context) AuthenticatedUser {
+	claims, _ := clerk.SessionClaimsFromContext(ctx)
+	customClaims := claims.Custom.(*types.CustomSessionClaims)
+	authenticatedUser := &AuthenticatedUser{
+		ID:          customClaims.UserId,
+		ClerkID:     claims.Subject,
+		WorkspaceID: customClaims.WorkspaceId,
+	}
+	return *authenticatedUser
+}

--- a/backend/pkg/context/webhook.go
+++ b/backend/pkg/context/webhook.go
@@ -23,7 +23,3 @@ func GetWebhookEvent(ctx context.Context) *types.WebhookEvent {
 	event, _ := ctx.Value(webhookEventKey).(*types.WebhookEvent)
 	return event
 }
-
-func GetActiveUserID(ctx context.Context) string {
-	return ctx.Value(types.ActiveSessionUserId).(string)
-}

--- a/backend/pkg/types/error_messages/errors.go
+++ b/backend/pkg/types/error_messages/errors.go
@@ -1,0 +1,38 @@
+package error_messages
+
+const (
+	ErrInvalidID            = "invalid ID"
+	ErrEncodeResponseFailed = "failed to encode response"
+	// priceList
+	ErrPriceListExists   = "priceList already exists"
+	ErrPriceListNotFound = "priceList not found"
+	ErrCreatePriceList   = "error creating priceList"
+	ErrDeletePriceList   = "error deleting priceList"
+	ErrUpdatePriceList   = "error updating priceList"
+	ErrFindPriceList     = "error finding priceList"
+	ErrFilterPriceList   = "error filtering priceList"
+
+	// priceListItem
+	ErrPriceListItemExists   = "priceListItem already exists"
+	ErrPriceListItemNotFound = "priceListItem not found"
+	ErrCreatePriceListItem   = "error creating priceListItem"
+	ErrCreatePriceListItems  = "error creating priceListItems"
+	ErrDeletePriceListItem   = "error deleting priceListItem"
+	ErrUpdatePriceListItem   = "error updating priceListItem"
+	ErrFindPriceListItem     = "error finding priceListItem"
+	ErrFilterPriceListItem   = "error filtering priceListItem"
+
+	// workspace
+	ErrWorkspaceExists   = "workspace already exists"
+	ErrWorkspaceNotFound = "workspace not found"
+	ErrCreateWorkspace   = "error creating workspace"
+	ErrUpdateWorkspace   = "error updating workspace"
+	ErrFindWorkspace     = "error finding workspace"
+
+	// distributor
+	ErrDistributorExists   = "distributor already exists"
+	ErrDistributorNotFound = "distributor not found"
+	ErrCreateDistributor   = "error creating distributor"
+	ErrUpdateDistributor   = "error updating distributor"
+	ErrFindDistributor     = "error finding distributor"
+)

--- a/backend/pkg/types/session_claims.go
+++ b/backend/pkg/types/session_claims.go
@@ -1,7 +1,8 @@
 package types
 
 type CustomSessionClaims struct {
-	UserId *string `json:"user_id"`
+	UserId      string `json:"user_id"`
+	WorkspaceId string `json:"workspace_id"`
 }
 
 const (

--- a/backend/pkg/types/session_claims.go
+++ b/backend/pkg/types/session_claims.go
@@ -4,7 +4,3 @@ type CustomSessionClaims struct {
 	UserId      string `json:"user_id"`
 	WorkspaceId string `json:"workspace_id"`
 }
-
-const (
-	ActiveSessionUserId = "session_user_id"
-)


### PR DESCRIPTION
- Add utility function to retrieve authenticated user from request
    This simplifies the process of accessing authenticated user fields such as workspaceId, userId, and clerk. These values will be used frequently throughout the codebase, so centralizing their retrieval improves maintain ability and reduces repetition.

- Remove logic for associating workspace with a distributor from create workspace service and use a usecase instead
- Add and use `createWorkspace` usecase to:
    - Create a workspace
    - Assign workspace to the distributor that creates the workspace
    - Set `workspace_id` on clerk user `public_metadata` object

- Improve error messages