### PR TITLE
Temporarily show signup section on signin form by commenting out hidden CSS

### DIFF
--- a/frontend/src/pages/auth/index.tsx
+++ b/frontend/src/pages/auth/index.tsx
@@ -6,7 +6,11 @@ export default function Auth() {
       <SignIn
         fallbackRedirectUrl="/"
         withSignUp={false}
-        appearance={{ elements: { footerAction: '!hidden' } }}
+        appearance={
+          {
+            /*elements: { footerAction: '!hidden' } */
+          }
+        }
       />
     </main>
   );


### PR DESCRIPTION
This change temporarily displays the signup section within the signin form when accessing a workspace by commenting out the CSS that hides it. This allows anyone to test the signup flow for the time being.