### PR TITLE
Add new update api to allow support updating pricelist `name` and `items`

### DIFF
--- a/backend/internal/repository/pricelist_repository.go
+++ b/backend/internal/repository/pricelist_repository.go
@@ -45,7 +45,15 @@ func (r *priceListRepository) Create(priceList *models.PriceList) error {
 }
 
 func (r *priceListRepository) Update(ID uint, priceList *models.PriceList) error {
-	return r.db.Where(whereID, ID).Updates(priceList).Error
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.PriceList{}).Where("id = ?", ID).Updates(priceList).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(priceList).Association("PriceListItems").Replace(priceList.PriceListItems); err != nil {
+			return err
+		}
+		return nil
+	})
 }
 func (r *priceListRepository) DeleteByID(ID string) error {
 	return r.db.Where(whereID, ID).Delete(&models.PriceList{}).Error

--- a/backend/internal/routes/pricelist_routes.go
+++ b/backend/internal/routes/pricelist_routes.go
@@ -24,8 +24,10 @@ func registerPriceListRoutes(router chi.Router, db *gorm.DB) {
 		// Get pricelist by ID
 		r.With(middleware.ValidatePriceListId(db)).Get("/{id}", priceListHandler.Get)
 
-		// Update pricelist by ID
+		// TODO: to be removed
 		r.With(middleware.ValidatePriceListId(db)).Patch("/{id}", priceListHandler.Update)
+		// Update pricelist by ID
+		r.With(middleware.ValidatePriceListId(db)).Put("/{id}", priceListHandler.Update)
 
 		// Delete pricelist by ID
 		r.With(middleware.ValidatePriceListId(db)).Delete("/{id}", priceListHandler.Delete)

--- a/backend/internal/service/pricelist_service.go
+++ b/backend/internal/service/pricelist_service.go
@@ -86,7 +86,7 @@ func (s *priceListService) Create(createPriceListReq *types.CreatePriceListReque
 }
 
 func (s *priceListService) Update(ID uint, updatePriceListRequest *types.UpdatePriceListRequest) (pricelist *models.PriceList, apiError *types.APIERROR) {
-	existingPriceList, err := s.repo.FindOneWithFields([]string{"id"}, map[string]any{"id": ID})
+	existingPriceList, err := s.repo.FindOneWithFields([]string{}, map[string]any{"id": ID})
 	if err != nil {
 		return nil, &types.APIERROR{Message: error_messages.ErrPriceListNotFound, Code: http.StatusNotFound}
 	}
@@ -95,6 +95,20 @@ func (s *priceListService) Update(ID uint, updatePriceListRequest *types.UpdateP
 	if updatePriceListRequest.Name != "" {
 		existingPriceList.Name = updatePriceListRequest.Name
 	}
+
+	priceListItems := make([]models.PriceListItem, 0, len(updatePriceListRequest.PriceListItems))
+
+	for _, item := range updatePriceListRequest.PriceListItems {
+		priceListItems = append(priceListItems, models.PriceListItem{
+			Description: item.Description,
+			Dimension:   item.Dimension,
+			Price:       item.Price,
+			WorkspaceID: existingPriceList.WorkspaceID,
+			PriceListID: existingPriceList.ID,
+		})
+	}
+
+	existingPriceList.PriceListItems = priceListItems
 
 	err = s.repo.Update(ID, existingPriceList)
 	if err != nil {

--- a/backend/pkg/types/pricelist.go
+++ b/backend/pkg/types/pricelist.go
@@ -13,7 +13,8 @@ type CreatePriceListRequest struct {
 }
 
 type UpdatePriceListRequest struct {
-	Name string `json:"name" validate:"required,min=10"`
+	Name           string                      `json:"name" validate:"required,min=5"`
+	PriceListItems []CreatPriceListItemRequest `json:"price_list_items" validate:"required,min=1,uniqueDimension,dive"`
 }
 
 type BulkDeletePriceListRequest struct {


### PR DESCRIPTION
Add new update api to allow support updating pricelist `name` and `items`. The older API doesn't support updating price list `items`


API: PUT api/pricelists/{id}
body: {name: "name", price_list_items: [{size: "40X40",..}]}